### PR TITLE
Bump version to 1.1.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dioxus-material-icons"
-version = "1.0.2"
+version = "1.1.0"
 edition = "2021"
 license = "MIT"
 description = "Material Icons for Dioxus"


### PR DESCRIPTION
Minor version change (not patch) because API isn't backwards compatible to version `1.0.2`