### PR TITLE
Update dioxus to 0.7

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ name = "button"
 path = "examples/button.rs"
 
 [dependencies]
-dioxus = "0.6"
+dioxus = "0.7"
 
 [dev-dependencies]
-dioxus = { version = "0.6", features = ["desktop"] }
+dioxus = { version = "0.7", features = ["desktop"] }


### PR DESCRIPTION
This updates dioxus to 0.7.

I've tested it with my own app, and the example looks like this:
<img width="828" height="666" alt="Bildschirmfoto vom 2025-11-08 09-17-27" src="https://github.com/user-attachments/assets/5febf649-998f-462d-9824-9c358ee839fc" />

Thank you for this useful crate!