### PR TITLE
docs: remove homepage and bump version to 4.0.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,6 @@ edition = "2021"
 license = "MIT"
 description = "Material Icons for Dioxus"
 repository = "https://github.com/lennartkloock/dioxus-material-icons"
-homepage = "https://lennart.codes/dioxus-material-icons"
 keywords = ["dioxus", "material-design", "icons", "ui", "gui"]
 categories = ["web-programming", "gui"]
 readme = "README.md"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dioxus-material-icons"
-version = "4.0.0"
+version = "4.0.1"
 edition = "2021"
 license = "MIT"
 description = "Material Icons for Dioxus"


### PR DESCRIPTION
The link is outdated